### PR TITLE
fix a drawback that will bring out an wrong route in parseing header such as

### DIFF
--- a/httpServer.lua
+++ b/httpServer.lua
@@ -137,9 +137,9 @@ end
 -- Middleware
 --------------------
 function parseHeader(req, res)
-	local _, _, method, path, vars = string.find(req.source, '([A-Z]+) (.+)?(.+) HTTP')
+	local _, _, method, path, vars = string.find(req.source, '([A-Z]+) (.+)?(.*) HTTP')
 	if method == nil then
-		_, _, method, path = string.find(req.source, '([A-Z]+) (.+) HTTP')
+		_, _, method, path = string.find(req.source, '([A-Z]+) (.*) HTTP')
 	end
 	local _GET = {}
 	if vars ~= nil then

--- a/httpServer.lua
+++ b/httpServer.lua
@@ -139,10 +139,10 @@ end
 function parseHeader(req, res)
 	local _, _, method, path, vars = string.find(req.source, '([A-Z]+) (.+)?(.*) HTTP')
 	if method == nil then
-		_, _, method, path = string.find(req.source, '([A-Z]+) (.*) HTTP')
+		_, _, method, path = string.find(req.source, '([A-Z]+) (.+) HTTP')
 	end
 	local _GET = {}
-	if vars ~= nil then
+	if (vars ~= nil and vars ~= '') then
 		vars = urlDecode(vars)
 		for k, v in string.gmatch(vars, '([^&]+)=([^&]*)&*') do
 			_GET[k] = v


### PR DESCRIPTION
When a url  with GET looks like `http://x.x.x.x/info?` rather than `http://x.x.x.x/info?xx=xx`,  the `req.path` will be `/info?` rather than the correct `/info`.